### PR TITLE
Pull Mesos from Apache repo

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clj-mesos "0.1.0"
+(defproject clj-mesos "0.1.0-SNAPSHOT"
   :description "FIXME: write description"
   :url "http://example.com/FIXME"
   :license {:name "Eclipse Public License"


### PR DESCRIPTION
Wanted to take this for a spin with 0.19.0 and ran into some issues. The first one being that protobuf and the mesos jar was outdated/unavailable. For what it is worth, the project file can pull those from Apache's repo. There are still issues with make-reflective-fn and launchTasks (which now has overloaded methods with the same argument count).
